### PR TITLE
Combinar Panel + Configuración en un dropdown 'Inicio'

### DIFF
--- a/app/components/navbar_component/navbar_component.html.erb
+++ b/app/components/navbar_component/navbar_component.html.erb
@@ -9,7 +9,32 @@
         </div>
         <div class="hidden md:block">
           <div class="ml-10 flex items-baseline space-x-4">
-            <%= link_to t('nav.dashboard'), root_path, class: "px-3 py-2 rounded-md text-sm font-medium #{active_class(root_path)}" %>
+            <% home_active = request.path == root_path || request.path.start_with?("/configuracion") %>
+            <div data-controller="dropdown" class="relative">
+              <button type="button"
+                      data-dropdown-target="button"
+                      data-action="click->dropdown#toggle"
+                      aria-expanded="false"
+                      aria-haspopup="true"
+                      class="<%= home_active ? 'bg-gray-900 text-white' : 'text-gray-300 hover:bg-gray-700 hover:text-white' %> inline-flex items-center gap-1 px-3 py-2 rounded-md text-sm font-medium">
+                <%= t('nav.home') %>
+                <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              <div data-dropdown-target="menu"
+                   class="hidden absolute left-0 mt-1 w-56 origin-top-left bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 z-10"
+                   role="menu">
+                <%= link_to t('nav.dashboard'), root_path,
+                            class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 first:rounded-t-md",
+                            role: "menuitem" %>
+                <% if helpers.authenticated? %>
+                  <%= link_to t('nav.settings'), settings_root_path,
+                              class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 last:rounded-b-md",
+                              role: "menuitem" %>
+                <% end %>
+              </div>
+            </div>
             <%= link_to t('nav.clients'), clients_path, class: "px-3 py-2 rounded-md text-sm font-medium #{active_class(clients_path)}" %>
             <%= link_to t('nav.suppliers'), suppliers_path, class: "px-3 py-2 rounded-md text-sm font-medium #{active_class(suppliers_path)}" %>
             <%= link_to t('nav.products'), products_path, class: "px-3 py-2 rounded-md text-sm font-medium #{active_class(products_path)}" %>
@@ -25,11 +50,7 @@
           <% end %>
           
           <% if helpers.authenticated? %>
-            <%= link_to t('nav.settings'), settings_root_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
-          <% end %>
-          
-          <% if helpers.authenticated? %>
-            <!-- Profile dropdown -->
+            <!-- Profile avatar -->
             <div class="ml-3 relative">
               <div>
                 <%= link_to settings_root_path, class: "bg-black flex text-sm rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-black focus:ring-white" do %>

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["menu", "button"]
+
+  connect() {
+    this.boundClickOutside = this.clickOutside.bind(this)
+    this.boundEscape = this.handleEscape.bind(this)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.boundClickOutside)
+    document.removeEventListener("keydown", this.boundEscape)
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    if (this.menuTarget.classList.contains("hidden")) {
+      this.open()
+    } else {
+      this.close()
+    }
+  }
+
+  open() {
+    this.menuTarget.classList.remove("hidden")
+    this.buttonTarget.setAttribute("aria-expanded", "true")
+    document.addEventListener("click", this.boundClickOutside)
+    document.addEventListener("keydown", this.boundEscape)
+  }
+
+  close() {
+    this.menuTarget.classList.add("hidden")
+    this.buttonTarget.setAttribute("aria-expanded", "false")
+    document.removeEventListener("click", this.boundClickOutside)
+    document.removeEventListener("keydown", this.boundEscape)
+  }
+
+  clickOutside(event) {
+    if (!this.element.contains(event.target)) this.close()
+  }
+
+  handleEscape(event) {
+    if (event.key === "Escape") this.close()
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
     language: "Language"
     admin: "Admin"
     settings: "Settings"
+    home: "Home"
     open_main_menu: "Open main menu"
 
   # Actions

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -60,6 +60,7 @@ es:
     language: "Idioma"
     admin: "Administración"
     settings: "Configuración"
+    home: "Inicio"
     open_main_menu: "Abrir menú principal"
 
   # Actions


### PR DESCRIPTION
## Summary

El navbar mostraba "Panel de control" y "Configuración" como dos items separados que comían espacio horizontal. Ahora ambos viven debajo de un único dropdown **"Inicio ▾"** a la izquierda.

Stacked sobre PR #135 (settings-hub-redesign).

## Cambios

- Nuevo `dropdown_controller.js` (Stimulus) con toggle, click-outside y Escape para cerrar
- "Inicio ▾" reemplaza el link "Panel de control" en el lado izquierdo del navbar
- Link suelto "Configuración" del lado derecho eliminado (ahora vive dentro del dropdown)
- El botón "Inicio" se resalta cuando estás en `/` o en cualquier `/configuracion/*`
- Avatar de la derecha sigue apuntando a `/configuracion/cuenta` como atajo rápido
- Móvil sin cambios — los dos links quedan planos donde el espacio no es problema
- `nav.home` agregado a en/es

## Test plan

- [ ] `bin/rails test` → 173 verde
- [ ] `bin/rubocop -f github` → exit 0
- [ ] Click en "Inicio" → menú se abre con Panel de control + Configuración
- [ ] Click afuera o Escape → menú cierra
- [ ] Visitar `/` → "Inicio" se ve activo
- [ ] Visitar `/configuracion/equipo` → "Inicio" se ve activo
- [ ] En móvil: ambos links siguen visibles planos

🤖 Generated with [Claude Code](https://claude.com/claude-code)